### PR TITLE
feat: add offline setup script and guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENT DEVELOPMENT GUIDELINES
+
+This repository contains a Rust crate implementing the Wang--Landau algorithm. All automated agents should follow these standards when contributing.
+
+## Commit Message Standards
+- Use **Conventional Commits** (https://www.conventionalcommits.org/) for all changes.
+- Begin the subject line with one of `feat:`, `fix:`, `docs:`, `chore:`, `test:`, or `refactor:`.
+- Keep messages concise; describe _why_ the change was made when not obvious.
+
+## Pull Request Guidelines
+- Title should summarize the change using a conventional commit style prefix.
+- Include a summary of changes, testing performed, and any relevant issues.
+- Ensure `cargo test` passes before requesting review.
+
+## Development Workflow
+- Group related changes into atomic commits.
+- Run `cargo fmt` and `cargo clippy` before committing, if available.
+- Update `CHANGELOG.md` for user facing changes.
+- Keep the `master` branch clean; open PRs from topic branches when working manually.
+
+## Versioning
+- This project follows [Semantic Versioning](https://semver.org/).
+- Increment the PATCH version for fixes, MINOR for new backwards compatible features, and MAJOR for breaking changes.
+
+## Testing Standards
+- Tests are written with Rust's built in test framework.
+- Maintain high coverage for core functionality.
+- New features should include appropriate unit tests in the `tests/` directory.
+
+## Pre-commit Checks
+- `cargo fmt -- --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+
+Agents should ensure these commands succeed before committing changes.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,17 @@ at your option.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be dual licensed as above, without any additional terms or conditions.
 
+## Development Setup
+
+Run the helper script `setup-dev.sh` once while online to install the Rust
+toolchain and vendor all dependencies:
+
+```bash
+./setup-dev.sh
+```
+
+Afterwards you can build and test the crate completely offline.
+
 ## References
 
 1. Wang, F. & Landau, D.P. (2001). "Efficient, Multiple-Range Random Walk Algorithm to Calculate the Density of States". *Physical Review Letters*, 86(10), 2050–2053.

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+# Setup development environment for wanglandau
+# This script installs required packages, the Rust toolchain, and vendors
+# dependencies so that the project can be built without an internet connection.
+# It is idempotent and safe to run multiple times.
+
+main() {
+    echo "[setup-dev] Starting environment setup";
+
+    install_packages
+    install_rust
+    vendor_dependencies
+    verify_build
+
+    echo "[setup-dev] Setup complete";
+}
+
+install_packages() {
+    echo "[setup-dev] Installing system packages";
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update -y
+        sudo apt-get install -y build-essential curl git
+    else
+        echo "Unsupported package manager. Install build tools, curl, and git manually." >&2
+    fi
+}
+
+install_rust() {
+    local desired_rust_version="1.87.0"
+    if ! command -v rustup >/dev/null 2>&1; then
+        echo "[setup-dev] Installing rustup";
+        curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain "$desired_rust_version"
+        export PATH="$HOME/.cargo/bin:$PATH"
+    else
+        export PATH="$HOME/.cargo/bin:$PATH"
+        local installed_version="$(rustc --version | awk '{print $2}')"
+        if [[ "$installed_version" != "$desired_rust_version" ]]; then
+            echo "[setup-dev] Installing Rust $desired_rust_version";
+            rustup toolchain install "$desired_rust_version" --profile minimal
+            rustup default "$desired_rust_version"
+        fi
+    fi
+}
+
+vendor_dependencies() {
+    echo "[setup-dev] Vendoring crate dependencies";
+    mkdir -p .cargo
+    if [ ! -f .cargo/config.toml ]; then
+        cat > .cargo/config.toml <<'CFG'
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+CFG
+    fi
+    cargo vendor vendor > /dev/null
+}
+
+verify_build() {
+    echo "[setup-dev] Building project to populate cache";
+    cargo build --tests > /dev/null
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add `setup-dev.sh` for offline Rust environment setup
- document usage in README
- add `AGENTS.md` with development standards

## Testing
- `bash setup-dev.sh`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684947ba0aa4832b9b4f386762e4dec5